### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v4"
+        uses: "actions/upload-artifact@v3"
         with:
           name: coverage-data
           path: ".coverage.*"


### PR DESCRIPTION
Reverts ologistio/ologist-cli#4 due to baffling design decision in [actions/upload-artifact/issues/478](https://github.com/actions/upload-artifact/issues/478).